### PR TITLE
Allow users to check off nominees with db persistance

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/CheckableRow.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/CheckableRow.kt
@@ -29,26 +29,19 @@ import androidx.compose.ui.unit.sp
 fun CheckableRow(
     state: CheckableRowState
 ) {
-    // This will need to be in the ViewModel later
-    val checked = remember { mutableStateOf(false) }
-
     Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.toggleable(
-            value = checked.value,
-            enabled = true,
+        modifier = Modifier
+            .toggleable(
+            value = state.isChecked,
+            onValueChange = { state.onCheckedChange.invoke() },
             role = Role.Checkbox
-        ) { isChecked ->
-            checked.value = isChecked
-        }
+        ),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
 
         Checkbox(
-            checked = checked.value,
-            enabled = true,
-            onCheckedChange = { isChecked ->
-                checked.value = isChecked
-            }
+            checked = state.isChecked,
+            onCheckedChange = null // to leverage only the row as clickable for now
         )
         Text(
             modifier = Modifier.weight(1f),
@@ -68,5 +61,7 @@ fun CheckableRow(
 data class CheckableRowState(
     val rowId: Long,
     val title: String,
+    val isChecked: Boolean,
+    val onCheckedChange: () -> Unit,
     @DrawableRes val endIcon: Int? = null,
 )

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/ExpandableCard.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/ExpandableCard.kt
@@ -35,7 +35,7 @@ fun ExpandableCard(
     state: ExpandableCardState,
     accessibilityState: ExpandableCardAccessibilityState,
 ) {
-    // TODO: move this into the VM with actions
+    // TODO: move this into the VM with actions - this can allow us to expand the first by default
     var showNominations by remember { mutableStateOf(false) }
     Card {
         Column {
@@ -84,6 +84,8 @@ fun ExpandableCard(
                             state = CheckableRowState(
                                 rowId = nominee.rowId,
                                 title = nominee.title,
+                                isChecked = nominee.isChecked,
+                                onCheckedChange = nominee.onCheckedChange,
                                 endIcon = nominee.endIcon
 //                                note = nominee.note,
 //                                secondary = nominee.secondary

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/screen/MainScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/screen/MainScreen.kt
@@ -99,15 +99,21 @@ fun MainScreenReadyPreview() {
                                     nomineeStates = listOf(
                                         CheckableRowState(
                                             rowId = 1,
-                                            title = "Star Wars: The Force Awakens"
+                                            title = "Star Wars: The Force Awakens",
+                                            isChecked = true,
+                                            onCheckedChange = {}
                                         ),
                                         CheckableRowState(
                                             rowId = 2,
-                                            title = "Harry Potter and the Order of the Phoenix"
+                                            title = "Harry Potter and the Order of the Phoenix",
+                                            isChecked = true,
+                                            onCheckedChange = {}
                                         ),
                                         CheckableRowState(
                                             rowId = 3,
-                                            title = "Space Balls II: The Search for More Money"
+                                            title = "Space Balls II: The Search for More Money",
+                                            isChecked = true,
+                                            onCheckedChange = {}
                                         ),
                                     )
                                 )

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/screen/MainScreenViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/screen/MainScreenViewModel.kt
@@ -50,27 +50,43 @@ class MainScreenViewModel(
         return this
             .groupBy { it.awardYear } // map of year: Long to awardNominees: List<SelectAllAwardNominees>
             .mapNotNull { year ->
-                SeasonEntryState(
-                    title = year.key.toString(),
-                    categoryStates = year.value.groupBy { it.categoryName }
-                        .mapNotNull { category ->
-                            ExpandableCardState(
-                                title = category.key,
-                                nomineeStates = category.value.map { nominee ->
-                                    CheckableRowState(
-                                        rowId = nominee.id,
-                                        title = nominee.name,
-                                        isChecked = nominee.watched,
-                                        onCheckedChange = { onCheckboxToggle(nominee.id, !nominee.watched) },
-                                        endIcon = if (nominee.won) R.drawable.ic_trophy_24 else null
-//                                    secondary = nominee.secondaryInfo.split(","),
-//                                    note = nominee.notes
-                                    )
-                                }
-                            )
-                        }
-                )
+                mapSeasonEntryState(year)
             }
+    }
+
+    private fun mapSeasonEntryState(year: Map.Entry<Long, List<SelectAllAwardNominees>>) =
+        SeasonEntryState(
+            title = year.key.toString(),
+            categoryStates = year.value.groupBy { it.categoryName }
+                .mapNotNull { category ->
+                    mapExpandableCardState(category)
+                }
+        )
+
+    private fun mapExpandableCardState(category: Map.Entry<String, List<SelectAllAwardNominees>>) =
+        ExpandableCardState(
+            title = category.key,
+            nomineeStates = category.value.map { nominee ->
+                mapCheckableRowState(nominee)
+            }
+        )
+
+    private fun mapCheckableRowState(nominee: SelectAllAwardNominees) =
+        CheckableRowState(
+            rowId = nominee.id,
+            title = nominee.name,
+            isChecked = nominee.watched,
+            onCheckedChange = {
+                onCheckboxToggle(
+                    rowId = nominee.id,
+                    isChecked = !nominee.watched
+                )
+            },
+            endIcon = getWinnerIcon(nominee.won)
+        )
+
+    private fun getWinnerIcon(isWinner: Boolean): Int? {
+        return if (isWinner) R.drawable.ic_trophy_24 else null
     }
 }
 


### PR DESCRIPTION
closes #1 

This will need updating to the shared VM in the future but I was studying this today pre interview to remember how to hoist the state and click actions into the VM. Please take a look at that @CodyEngel if you have a few as I feel like it might somehow be backwards with the lambdas?

I want to get tests in soon for the shared code. So I will be adding that to the board soon.

Per the video below, checking the box is held when put into the background and when closed. Not shown, Android Studio has a db inspector that showed the column value being toggled to 1 or 0 depending on if checked or not.

https://github.com/ddaypunk/aperture/assets/2991755/8cf8e2eb-25e4-4666-8105-173aea1bd855


