### PR TITLE
Android | Update UI Styling and available data

### DIFF
--- a/.fleet/run.json
+++ b/.fleet/run.json
@@ -1,15 +1,15 @@
 {
-    "configurations": [
-        {
-            "name": "iosApp",
-            "type": "xcode-app",
-            "workingDir": "/Users/giovanninoa/code/aperture",
-            "buildTarget": {
-                "project": "iosApp",
-                "target": "iosApp"
-            },
-            "configuration": "Debug",
-            "destination": "iPhone 14 Pro Max | iOS 17.0"
-        }
-    ]
+  "configurations": [
+    {
+      "name": "iosApp",
+      "type": "xcode-app",
+      "workingDir": "/Users/giovanninoa/code/aperture",
+      "buildTarget": {
+        "project": "iosApp",
+        "target": "iosApp"
+      },
+      "configuration": "Debug",
+      "destination": "iPhone 14 Pro Max | iOS 17.0"
+    }
+  ]
 }

--- a/RESOURCES.md
+++ b/RESOURCES.md
@@ -1,13 +1,15 @@
 ## Project examples
 
-[github/todometer-kmp](https://github.com/serbelga/Todometer-KMP/tree/main) - A completed OSS app using KMP and
+[github/todometer-kmp](https://github.com/serbelga/Todometer-KMP/tree/main) - A completed OSS app
+using KMP and
 sqldelight - LARGE mutli module feel and a bit confusing right now
 
 ## KMP Tools
 
 [KMP Compatibility Guide](https://kotlinlang.org/docs/multiplatform-compatibility-guide.html)
 [KMM plugin releases](https://kotlinlang.org/docs/multiplatform-plugin-releases.html#release-details)
-[github/KMM-ViewModel](https://github.com/rickclephas/KMM-ViewModel) - need to see if this is useful to have a single
+[github/KMM-ViewModel](https://github.com/rickclephas/KMM-ViewModel) - need to see if this is useful
+to have a single
 view model for all platforms instead of building our own
 [github/kmp-awesome](https://github.com/terrakok/kmp-awesome) A nice list of useful KMP tools
 
@@ -17,9 +19,11 @@ view model for all platforms instead of building our own
 
 ## Android Stuff
 
-[developers.android/compose ui architecture](https://developer.android.com/jetpack/compose/architecture) - Just a quick
+[developers.android/compose ui architecture](https://developer.android.com/jetpack/compose/architecture) -
+Just a quick
 reminder of UDF and such
-[developers.android/domain and use cases](https://developer.android.com/topic/architecture/domain-layer?hl=en) - we
+[developers.android/domain and use cases](https://developer.android.com/topic/architecture/domain-layer?hl=en) -
+we
 should use this style I think and get used to it
 
 ## Dependency Injection

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -25,6 +25,7 @@ kotlin {
             implementation(libs.androidx.lifecycle.compose.viewmodel)
             implementation(libs.koin.core)
             implementation(libs.koin.android)
+            implementation(libs.coil.compose)
         }
         commonMain.dependencies {
             implementation(compose.runtime)

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/AppMockData.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/AppMockData.kt
@@ -1,99 +1,99 @@
 package com.ddaypunk.aperture
-
-import com.ddaypunk.aperture.data.Award
-import com.ddaypunk.aperture.data.Nominee
-import com.ddaypunk.aperture.data.Season
-
-val mockData = listOf(
-    Season(
-        year = 2022,
-        listOf(
-            Award(
-                category = "Best Motion Picture of the Year",
-                nominations = listOf(
-                    Nominee(
-                        name = "CODA",
-                        secondary = listOf(
-                            "Philippe Rousselet",
-                            "Fabrice Gianfermi",
-                            "Patrick Wachsberger"
-                        ),
-                        won = true,
-                        note = "CODA became the first movie produced by a streaming service to win Best Picture"
-                    ),
-                    Nominee(
-                        name = "Belfast",
-                        secondary = listOf(
-                            "Laura Berwick",
-                            "Kenneth Branagh",
-                            "Becca Kovacik",
-                            "Tamar Thomas"
-                        )
-                    ),
-                    Nominee(
-                        name = "Don't Look Up",
-                        secondary = listOf(
-                            "Adam McKay",
-                            "Kevin J. Messick"
-                        ),
-                    ),
-                    Nominee(
-                        name = "Drive My Car",
-                        secondary = listOf(
-                            "Teruhisa Yamamoto"
-                        ),
-                    ),
-                    Nominee(
-                        name = "Dune",
-                        secondary = listOf(
-                            "Mary Parent",
-                            "Denis Villeneuve",
-                            "Cale Boyter"
-                        ),
-                    ),
-                    Nominee(
-                        name = "King Richard",
-                        secondary = listOf(
-                            "Tim White",
-                            "Trevor White",
-                            "Will Smith"
-                        ),
-                    ),
-                    Nominee(
-                        name = "Licorice Pizza",
-                        secondary = listOf(
-                            "Sara Murphy",
-                            "Adam Somner",
-                            "Paul Thomas Anderson"
-                        ),
-                    ),
-                    Nominee(
-                        name = "Nightmare Alley",
-                        secondary = listOf(
-                            "Guillermo del Toro",
-                            "J. Miles Dale",
-                            "Bradley Cooper"
-                        ),
-                    ),
-                    Nominee(
-                        name = "The Power of the Dog",
-                        secondary = listOf(
-                            "Jane Campion",
-                            "Tanya Seghatchian",
-                            "Emile Sherman",
-                            "Iain Canning",
-                            "Roger Frappier"
-                        ),
-                    ),
-                    Nominee(
-                        name = "West Side Story",
-                        secondary = listOf(
-                            "Steven Spielberg",
-                            "Kristie Macosko Krieger"
-                        ),
-                    ),
-                ),
-            )
-        )
-    )
-)
+//
+//import com.ddaypunk.aperture.data.Award
+//import com.ddaypunk.aperture.data.Nominee
+//import com.ddaypunk.aperture.data.Season
+//
+//val mockData = listOf(
+//    Season(
+//        year = 2022,
+//        listOf(
+//            Award(
+//                category = "Best Motion Picture of the Year",
+//                nominations = listOf(
+//                    Nominee(
+//                        name = "CODA",
+//                        secondary = listOf(
+//                            "Philippe Rousselet",
+//                            "Fabrice Gianfermi",
+//                            "Patrick Wachsberger"
+//                        ),
+//                        won = true,
+//                        note = "CODA became the first movie produced by a streaming service to win Best Picture"
+//                    ),
+//                    Nominee(
+//                        name = "Belfast",
+//                        secondary = listOf(
+//                            "Laura Berwick",
+//                            "Kenneth Branagh",
+//                            "Becca Kovacik",
+//                            "Tamar Thomas"
+//                        )
+//                    ),
+//                    Nominee(
+//                        name = "Don't Look Up",
+//                        secondary = listOf(
+//                            "Adam McKay",
+//                            "Kevin J. Messick"
+//                        ),
+//                    ),
+//                    Nominee(
+//                        name = "Drive My Car",
+//                        secondary = listOf(
+//                            "Teruhisa Yamamoto"
+//                        ),
+//                    ),
+//                    Nominee(
+//                        name = "Dune",
+//                        secondary = listOf(
+//                            "Mary Parent",
+//                            "Denis Villeneuve",
+//                            "Cale Boyter"
+//                        ),
+//                    ),
+//                    Nominee(
+//                        name = "King Richard",
+//                        secondary = listOf(
+//                            "Tim White",
+//                            "Trevor White",
+//                            "Will Smith"
+//                        ),
+//                    ),
+//                    Nominee(
+//                        name = "Licorice Pizza",
+//                        secondary = listOf(
+//                            "Sara Murphy",
+//                            "Adam Somner",
+//                            "Paul Thomas Anderson"
+//                        ),
+//                    ),
+//                    Nominee(
+//                        name = "Nightmare Alley",
+//                        secondary = listOf(
+//                            "Guillermo del Toro",
+//                            "J. Miles Dale",
+//                            "Bradley Cooper"
+//                        ),
+//                    ),
+//                    Nominee(
+//                        name = "The Power of the Dog",
+//                        secondary = listOf(
+//                            "Jane Campion",
+//                            "Tanya Seghatchian",
+//                            "Emile Sherman",
+//                            "Iain Canning",
+//                            "Roger Frappier"
+//                        ),
+//                    ),
+//                    Nominee(
+//                        name = "West Side Story",
+//                        secondary = listOf(
+//                            "Steven Spielberg",
+//                            "Kristie Macosko Krieger"
+//                        ),
+//                    ),
+//                ),
+//            )
+//        )
+//    )
+//)

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/CheckableRow.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/CheckableRow.kt
@@ -29,26 +29,19 @@ import androidx.compose.ui.unit.sp
 fun CheckableRow(
     state: CheckableRowState
 ) {
-    // This will need to be in the ViewModel later
-    val checked = remember { mutableStateOf(false) }
-
     Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.toggleable(
-            value = checked.value,
-            enabled = true,
+        modifier = Modifier
+            .toggleable(
+            value = state.isChecked,
+            onValueChange = { state.onCheckedChange.invoke() },
             role = Role.Checkbox
-        ) { isChecked ->
-            checked.value = isChecked
-        }
+        ),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
 
         Checkbox(
-            checked = checked.value,
-            enabled = true,
-            onCheckedChange = { isChecked ->
-                checked.value = isChecked
-            }
+            checked = state.isChecked,
+            onCheckedChange = null // to leverage only the row as clickable for now
         )
         Text(
             modifier = Modifier.weight(1f),
@@ -68,5 +61,7 @@ fun CheckableRow(
 data class CheckableRowState(
     val rowId: Long,
     val title: String,
+    val isChecked: Boolean,
+    val onCheckedChange: () -> Unit,
     @DrawableRes val endIcon: Int? = null,
 )

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/CheckableRow.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/CheckableRow.kt
@@ -1,23 +1,23 @@
 package com.ddaypunk.aperture.component
 
-import androidx.annotation.DrawableRes
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Badge
 import androidx.compose.material.Checkbox
+import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.painter.BrushPainter
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -35,6 +35,7 @@ fun CheckableRow(
     with(state) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(end = 16.dp)
         ) {
 
             Checkbox(
@@ -62,13 +63,13 @@ fun CheckableRow(
                     )
                 )
             }
-            endIcon?.let { nonNullEndIcon ->
-                Image(
-                    modifier = Modifier.padding(end = 16.dp),
-                    painter = painterResource(nonNullEndIcon),
-                    contentDescription = "category winner",
-                    colorFilter = ColorFilter.tint(Color.Yellow)
-                )
+            if (isWinner) {
+                Badge(
+                    backgroundColor = MaterialTheme.colors.primary,
+                    contentColor = MaterialTheme.colors.onPrimary
+                ) {
+                    Icon(imageVector = Icons.Default.Star, contentDescription = "category winner")
+                }
             }
         }
     }
@@ -85,7 +86,7 @@ fun CheckableRowPreview() {
                     title = "Star Wars: The Force Awakens",
                     isChecked = false,
                     onCheckedChange = {},
-                    endIcon = null
+                    isWinner = false
                 )
             )
         }
@@ -99,5 +100,5 @@ data class CheckableRowState(
     val isChecked: Boolean,
     val onCheckedChange: () -> Unit,
     val image: String? = null,
-    @DrawableRes val endIcon: Int? = null,
+    val isWinner: Boolean = false
 )

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/CheckableRow.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/CheckableRow.kt
@@ -8,8 +8,7 @@ import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.Checkbox
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -40,6 +39,7 @@ fun CheckableRow(
     ) {
 
         Checkbox(
+            modifier = Modifier.padding(8.dp),
             checked = state.isChecked,
             onCheckedChange = null // to leverage only the row as clickable for now
         )
@@ -58,6 +58,7 @@ fun CheckableRow(
     }
 }
 
+@Immutable
 data class CheckableRowState(
     val rowId: Long,
     val title: String,

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/CheckableRow.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/CheckableRow.kt
@@ -4,19 +4,24 @@ import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.Checkbox
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.painter.BrushPainter
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
 
 /**
  * A component to display a row of data with a checkbox and a possible end of row icon
@@ -28,31 +33,60 @@ import androidx.compose.ui.unit.sp
 fun CheckableRow(
     state: CheckableRowState
 ) {
-    Row(
-        modifier = Modifier
-            .toggleable(
-            value = state.isChecked,
-            onValueChange = { state.onCheckedChange.invoke() },
-            role = Role.Checkbox
-        ),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
+    with(state) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
 
-        Checkbox(
-            modifier = Modifier.padding(8.dp),
-            checked = state.isChecked,
-            onCheckedChange = null // to leverage only the row as clickable for now
-        )
-        Text(
-            modifier = Modifier.weight(1f),
-            text = state.title, fontSize = 18.sp
-        )
-        state.endIcon?.let { nonNullEndIcon ->
-            Image(
-                modifier = Modifier.padding(end = 16.dp),
-                painter = painterResource(nonNullEndIcon),
-                contentDescription = "category winner",
-                colorFilter = ColorFilter.tint(Color.Yellow)
+            Checkbox(
+                modifier = Modifier.padding(8.dp),
+                checked = isChecked,
+                onCheckedChange = { onCheckedChange.invoke() }
+            )
+            Text(
+                modifier = Modifier.weight(1f),
+                text = title, fontSize = 18.sp
+            )
+            image?.let { nonNullImage ->
+                AsyncImage(
+                    model = nonNullImage,
+                    contentDescription = "$title move poster",
+                    contentScale = ContentScale.Crop,
+                    placeholder = BrushPainter(
+                        Brush.linearGradient(
+                            listOf(
+                                Color(color = 0xFFFFFFFF),
+                                Color(color = 0xFFDDDDDD),
+                            )
+                        )
+                    )
+                )
+            }
+            endIcon?.let { nonNullEndIcon ->
+                Image(
+                    modifier = Modifier.padding(end = 16.dp),
+                    painter = painterResource(nonNullEndIcon),
+                    contentDescription = "category winner",
+                    colorFilter = ColorFilter.tint(Color.Yellow)
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun CheckableRowPreview() {
+    MaterialTheme {
+        Surface(color = MaterialTheme.colors.background) {
+            CheckableRow(
+                state = CheckableRowState(
+                    rowId = 1,
+                    title = "Star Wars: The Force Awakens",
+                    isChecked = false,
+                    onCheckedChange = {},
+                    endIcon = null
+                )
             )
         }
     }
@@ -64,5 +98,6 @@ data class CheckableRowState(
     val title: String,
     val isChecked: Boolean,
     val onCheckedChange: () -> Unit,
+    val image: String? = null,
     @DrawableRes val endIcon: Int? = null,
 )

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/CheckableRow.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/CheckableRow.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 
 /**
@@ -45,7 +44,8 @@ fun CheckableRow(
             )
             Text(
                 modifier = Modifier.weight(1f),
-                text = title, fontSize = 18.sp
+                text = title,
+                style = MaterialTheme.typography.body1
             )
             image?.let { nonNullImage ->
                 AsyncImage(

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/ExpandableCard.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/ExpandableCard.kt
@@ -4,6 +4,8 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.Card
@@ -81,7 +83,7 @@ fun ExpandableCard(
                 visible = showNominations
             ) {
                 Column {
-                    state.nomineeStates.forEach { nominee ->
+                    state.nomineeStates.forEachIndexed { index, nominee ->
                         key(nominee.rowId) {
                             CheckableRow(
                                 state = CheckableRowState(
@@ -89,9 +91,13 @@ fun ExpandableCard(
                                     title = nominee.title,
                                     isChecked = nominee.isChecked,
                                     onCheckedChange = nominee.onCheckedChange,
+                                    image = nominee.image,
                                     endIcon = nominee.endIcon
                                 )
                             )
+                            if (index < state.nomineeStates.size) {
+                                Spacer(modifier = Modifier.height(8.dp))
+                            }
                         }
                     }
                 }

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/ExpandableCard.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/ExpandableCard.kt
@@ -92,7 +92,7 @@ fun ExpandableCard(
                                     isChecked = nominee.isChecked,
                                     onCheckedChange = nominee.onCheckedChange,
                                     image = nominee.image,
-                                    endIcon = nominee.endIcon
+                                    isWinner = nominee.isWinner
                                 )
                             )
                             if (index != state.nomineeStates.size - 1) {

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/ExpandableCard.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/ExpandableCard.kt
@@ -4,8 +4,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.Card
@@ -83,7 +81,7 @@ fun ExpandableCard(
                 visible = showNominations
             ) {
                 Column {
-                    state.nomineeStates.forEachIndexed { index, nominee ->
+                    state.nomineeStates.forEach { nominee ->
                         key(nominee.rowId) {
                             CheckableRow(
                                 state = CheckableRowState(
@@ -95,9 +93,6 @@ fun ExpandableCard(
                                     endIcon = nominee.endIcon
                                 )
                             )
-                            if (index < state.nomineeStates.size) {
-                                Spacer(modifier = Modifier.height(8.dp))
-                            }
                         }
                     }
                 }

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/ExpandableCard.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/ExpandableCard.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.Card
+import androidx.compose.material.Divider
 import androidx.compose.material.IconToggleButton
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
@@ -21,7 +23,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.ddaypunk.aperture.R
 
 /**
@@ -56,7 +57,7 @@ fun ExpandableCard(
                 Text(
                     modifier = Modifier.weight(1f),
                     text = state.title,
-                    fontSize = 20.sp
+                    style = MaterialTheme.typography.body1
                 )
                 IconToggleButton(
                     checked = showNominations,
@@ -80,8 +81,9 @@ fun ExpandableCard(
             AnimatedVisibility(
                 visible = showNominations
             ) {
+                Divider()
                 Column {
-                    state.nomineeStates.forEach { nominee ->
+                    state.nomineeStates.forEachIndexed { index, nominee ->
                         key(nominee.rowId) {
                             CheckableRow(
                                 state = CheckableRowState(
@@ -93,6 +95,9 @@ fun ExpandableCard(
                                     endIcon = nominee.endIcon
                                 )
                             )
+                            if (index != state.nomineeStates.size - 1) {
+                                Divider(modifier = Modifier.padding(horizontal = 16.dp))
+                            }
                         }
                     }
                 }

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/ExpandableCard.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/ExpandableCard.kt
@@ -35,7 +35,7 @@ fun ExpandableCard(
     state: ExpandableCardState,
     accessibilityState: ExpandableCardAccessibilityState,
 ) {
-    // TODO: move this into the VM with actions
+    // TODO: move this into the VM with actions - this can allow us to expand the first by default
     var showNominations by remember { mutableStateOf(false) }
     Card {
         Column {
@@ -84,6 +84,8 @@ fun ExpandableCard(
                             state = CheckableRowState(
                                 rowId = nominee.rowId,
                                 title = nominee.title,
+                                isChecked = nominee.isChecked,
+                                onCheckedChange = nominee.onCheckedChange,
                                 endIcon = nominee.endIcon
 //                                note = nominee.note,
 //                                secondary = nominee.secondary

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/ExpandableCard.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/ExpandableCard.kt
@@ -10,7 +10,9 @@ import androidx.compose.material.Card
 import androidx.compose.material.IconToggleButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -80,17 +82,17 @@ fun ExpandableCard(
             ) {
                 Column {
                     state.nomineeStates.forEach { nominee ->
-                        CheckableRow(
-                            state = CheckableRowState(
-                                rowId = nominee.rowId,
-                                title = nominee.title,
-                                isChecked = nominee.isChecked,
-                                onCheckedChange = nominee.onCheckedChange,
-                                endIcon = nominee.endIcon
-//                                note = nominee.note,
-//                                secondary = nominee.secondary
+                        key(nominee.rowId) {
+                            CheckableRow(
+                                state = CheckableRowState(
+                                    rowId = nominee.rowId,
+                                    title = nominee.title,
+                                    isChecked = nominee.isChecked,
+                                    onCheckedChange = nominee.onCheckedChange,
+                                    endIcon = nominee.endIcon
+                                )
                             )
-                        )
+                        }
                     }
                 }
             }
@@ -98,11 +100,13 @@ fun ExpandableCard(
     }
 }
 
+@Immutable
 data class ExpandableCardState(
     val title: String,
     val nomineeStates: List<CheckableRowState>
 )
 
+@Immutable
 data class ExpandableCardAccessibilityState(
     val seasonYear: String
 )

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/SectionHeader.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/SectionHeader.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
@@ -42,6 +43,7 @@ fun SectionHeader(
     }
 }
 
+@Immutable
 data class SectionHeaderState(
     val title: String
 )

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/SectionHeader.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/component/SectionHeader.kt
@@ -1,19 +1,14 @@
 package com.ddaypunk.aperture.component
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 
 /**
  * Displays a single date header representing one season of an awards show
@@ -26,19 +21,14 @@ fun SectionHeader(
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .background(Color.DarkGray)
     ) {
         Text(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = 8.dp),
             text = state.title,
-            fontSize = 24.sp,
-            fontWeight = FontWeight.Bold,
-            textAlign = TextAlign.Center,
-            textDecoration = TextDecoration.Underline,
-            color = Color.White
-
+            style = MaterialTheme.typography.h5,
+            color = MaterialTheme.colors.onSurface
         )
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/screen/MainScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/screen/MainScreen.kt
@@ -99,15 +99,21 @@ fun MainScreenReadyPreview() {
                                     nomineeStates = listOf(
                                         CheckableRowState(
                                             rowId = 1,
-                                            title = "Star Wars: The Force Awakens"
+                                            title = "Star Wars: The Force Awakens",
+                                            isChecked = true,
+                                            onCheckedChange = {}
                                         ),
                                         CheckableRowState(
                                             rowId = 2,
-                                            title = "Harry Potter and the Order of the Phoenix"
+                                            title = "Harry Potter and the Order of the Phoenix",
+                                            isChecked = true,
+                                            onCheckedChange = {}
                                         ),
                                         CheckableRowState(
                                             rowId = 3,
-                                            title = "Space Balls II: The Search for More Money"
+                                            title = "Space Balls II: The Search for More Money",
+                                            isChecked = true,
+                                            onCheckedChange = {}
                                         ),
                                     )
                                 )

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/screen/MainScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/screen/MainScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -90,39 +91,41 @@ fun MainScreenReady(state: MainScreenState.Ready) {
 @Composable
 fun MainScreenReadyPreview() {
     MaterialTheme {
-        MainScreenReady(
-            state = MainScreenState.Ready(
-                seasons = listOf(
-                    SeasonEntryState(
-                        title = "2024",
-                        categoryStates = listOf(
-                            ExpandableCardState(
-                                title = "Best Previews Ever",
-                                nomineeStates = listOf(
-                                    CheckableRowState(
-                                        rowId = 1,
-                                        title = "Star Wars: The Force Awakens",
-                                        isChecked = true,
-                                        onCheckedChange = {}
-                                    ),
-                                    CheckableRowState(
-                                        rowId = 2,
-                                        title = "Harry Potter and the Order of the Phoenix",
-                                        isChecked = true,
-                                        onCheckedChange = {}
-                                    ),
-                                    CheckableRowState(
-                                        rowId = 3,
-                                        title = "Space Balls II: The Search for More Money",
-                                        isChecked = true,
-                                        onCheckedChange = {}
-                                    ),
+        Surface {
+            MainScreenReady(
+                state = MainScreenState.Ready(
+                    seasons = listOf(
+                        SeasonEntryState(
+                            title = "2024",
+                            categoryStates = listOf(
+                                ExpandableCardState(
+                                    title = "Best Previews Ever",
+                                    nomineeStates = listOf(
+                                        CheckableRowState(
+                                            rowId = 1,
+                                            title = "Star Wars: The Force Awakens",
+                                            isChecked = true,
+                                            onCheckedChange = {}
+                                        ),
+                                        CheckableRowState(
+                                            rowId = 2,
+                                            title = "Harry Potter and the Order of the Phoenix",
+                                            isChecked = true,
+                                            onCheckedChange = {}
+                                        ),
+                                        CheckableRowState(
+                                            rowId = 3,
+                                            title = "Space Balls II: The Search for More Money",
+                                            isChecked = true,
+                                            onCheckedChange = {}
+                                        ),
+                                    )
                                 )
                             )
                         )
                     )
                 )
             )
-        )
+        }
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/screen/MainScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/screen/MainScreen.kt
@@ -29,9 +29,12 @@ fun MainScreen(
 ) {
     val state = viewModel.uiState.collectAsState()
 
-    when(state.value) {
+    when (state.value) {
         is MainScreenState.Ready -> MainScreenReady(state.value as MainScreenState.Ready)
         is MainScreenState.Loading -> MainScreenLoading()
+        else -> {
+            // TODO: handle error state
+        }
     }
 }
 
@@ -56,8 +59,8 @@ fun MainScreenReady(state: MainScreenState.Ready) {
         verticalArrangement = Arrangement
             .spacedBy(8.dp)
     ) {
-        with(state.uiState) {
-            seasons?.let { nonNullSeasons ->
+        with(state) {
+            seasons.let { nonNullSeasons ->
                 nonNullSeasons.forEach { season ->
                     stickyHeader {
                         SectionHeader(
@@ -89,33 +92,31 @@ fun MainScreenReadyPreview() {
     MaterialTheme {
         MainScreenReady(
             state = MainScreenState.Ready(
-                uiState = MainScreenUiState(
-                    seasons = listOf(
-                        SeasonEntryState(
-                            title = "2024",
-                            categoryStates = listOf(
-                                ExpandableCardState(
-                                    title = "Best Previews Ever",
-                                    nomineeStates = listOf(
-                                        CheckableRowState(
-                                            rowId = 1,
-                                            title = "Star Wars: The Force Awakens",
-                                            isChecked = true,
-                                            onCheckedChange = {}
-                                        ),
-                                        CheckableRowState(
-                                            rowId = 2,
-                                            title = "Harry Potter and the Order of the Phoenix",
-                                            isChecked = true,
-                                            onCheckedChange = {}
-                                        ),
-                                        CheckableRowState(
-                                            rowId = 3,
-                                            title = "Space Balls II: The Search for More Money",
-                                            isChecked = true,
-                                            onCheckedChange = {}
-                                        ),
-                                    )
+                seasons = listOf(
+                    SeasonEntryState(
+                        title = "2024",
+                        categoryStates = listOf(
+                            ExpandableCardState(
+                                title = "Best Previews Ever",
+                                nomineeStates = listOf(
+                                    CheckableRowState(
+                                        rowId = 1,
+                                        title = "Star Wars: The Force Awakens",
+                                        isChecked = true,
+                                        onCheckedChange = {}
+                                    ),
+                                    CheckableRowState(
+                                        rowId = 2,
+                                        title = "Harry Potter and the Order of the Phoenix",
+                                        isChecked = true,
+                                        onCheckedChange = {}
+                                    ),
+                                    CheckableRowState(
+                                        rowId = 3,
+                                        title = "Space Balls II: The Search for More Money",
+                                        isChecked = true,
+                                        onCheckedChange = {}
+                                    ),
                                 )
                             )
                         )

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/screen/MainScreenViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/screen/MainScreenViewModel.kt
@@ -50,27 +50,43 @@ class MainScreenViewModel(
         return this
             .groupBy { it.awardYear } // map of year: Long to awardNominees: List<SelectAllAwardNominees>
             .mapNotNull { year ->
-                SeasonEntryState(
-                    title = year.key.toString(),
-                    categoryStates = year.value.groupBy { it.categoryName }
-                        .mapNotNull { category ->
-                            ExpandableCardState(
-                                title = category.key,
-                                nomineeStates = category.value.map { nominee ->
-                                    CheckableRowState(
-                                        rowId = nominee.id,
-                                        title = nominee.name,
-                                        isChecked = nominee.watched,
-                                        onCheckedChange = { onCheckboxToggle(nominee.id, !nominee.watched) },
-                                        endIcon = if (nominee.won) R.drawable.ic_trophy_24 else null
-//                                    secondary = nominee.secondaryInfo.split(","),
-//                                    note = nominee.notes
-                                    )
-                                }
-                            )
-                        }
-                )
+                mapSeasonEntryState(year)
             }
+    }
+
+    private fun mapSeasonEntryState(year: Map.Entry<Long, List<SelectAllAwardNominees>>) =
+        SeasonEntryState(
+            title = year.key.toString(),
+            categoryStates = year.value.groupBy { it.categoryName }
+                .mapNotNull { category ->
+                    mapExpandableCardState(category)
+                }
+        )
+
+    private fun mapExpandableCardState(category: Map.Entry<String, List<SelectAllAwardNominees>>) =
+        ExpandableCardState(
+            title = category.key,
+            nomineeStates = category.value.map { nominee ->
+                mapCheckableRowState(nominee)
+            }
+        )
+
+    private fun mapCheckableRowState(nominee: SelectAllAwardNominees) =
+        CheckableRowState(
+            rowId = nominee.id,
+            title = nominee.name,
+            isChecked = nominee.watched,
+            onCheckedChange = {
+                onCheckboxToggle(
+                    rowId = nominee.id,
+                    isChecked = !nominee.watched
+                )
+            },
+            endIcon = getWinnerIcon(nominee.won)
+        )
+
+    private fun getWinnerIcon(isWinner: Boolean): Int? {
+        return if (isWinner) R.drawable.ic_trophy_24 else null
     }
 }
 

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/screen/MainScreenViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/screen/MainScreenViewModel.kt
@@ -1,6 +1,7 @@
 package com.ddaypunk.aperture.screen
 
 import ApertureDatabaseRepository
+import androidx.compose.runtime.Stable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ddaypunk.aperture.R
@@ -8,42 +9,39 @@ import com.ddaypunk.aperture.component.CheckableRowState
 import com.ddaypunk.aperture.component.ExpandableCardState
 import com.ddaypunk.aperture.db.SelectAllAwardNominees
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 class MainScreenViewModel(
+
 ) : ViewModel(), KoinComponent {
-    private val _uiState = MutableStateFlow<MainScreenState>(MainScreenState.Loading)
-    val uiState: StateFlow<MainScreenState> = _uiState.asStateFlow()
     private val repository: ApertureDatabaseRepository by inject()
+
+    private val _uiState = MutableStateFlow<MainScreenState>(MainScreenState.Loading)
+    val uiState = _uiState.asStateFlow()
 
     init {
         viewModelScope.launch {
-            val state = mapDataToState(repository.getAllAwardNominees())
-            // emit the state to the UI
-            _uiState.update {
-                MainScreenState.Ready(uiState = state)
-            }
+            val repositoryFlow = repository.getAllAwardNomineesFlow()
+
+            repositoryFlow.onStart { _uiState.emit(MainScreenState.Loading) }
+                .catch { _uiState.emit(MainScreenState.Error("Error retrieving data from the database")) }
+                .collect { data ->
+                    _uiState.emit(
+                        MainScreenState.Ready(
+                            seasons = data.toListOfSeasonEntryStates()
+                        )
+                    )
+                }
         }
     }
 
-    private fun mapDataToState(data: List<SelectAllAwardNominees>) =
-        MainScreenUiState(
-            seasons = data.toListOfSeasonEntryStates()
-        )
-
     fun onCheckboxToggle(rowId: Long, isChecked: Boolean) {
         repository.updateNomineeWatched(rowId, isChecked)
-
-        val state = mapDataToState(repository.getAllAwardNominees())
-        // emit the state to the UI
-        _uiState.update {
-            MainScreenState.Ready(uiState = state)
-        }
     }
 
     private fun List<SelectAllAwardNominees>.toListOfSeasonEntryStates(): List<SeasonEntryState> {
@@ -90,15 +88,14 @@ class MainScreenViewModel(
     }
 }
 
+@Stable
 sealed class MainScreenState {
     data object Loading : MainScreenState()
-    data class Ready(val uiState: MainScreenUiState) : MainScreenState()
+    data class Ready(val seasons: List<SeasonEntryState>) : MainScreenState()
+    data class Error(val message: String) : MainScreenState()
 }
 
-data class MainScreenUiState(
-    val seasons: List<SeasonEntryState>? = emptyList()
-)
-
+@Stable
 data class SeasonEntryState(
     val title: String,
     val categoryStates: List<ExpandableCardState>

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/screen/MainScreenViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/screen/MainScreenViewModel.kt
@@ -80,6 +80,9 @@ class MainScreenViewModel(
                     isChecked = !nominee.watched
                 )
             },
+            // TODO: make call to KTOR for poster image
+            // TODO: in future, check if in persistence, otherwise make call and store
+            //  image = ,
             endIcon = getWinnerIcon(nominee.won)
         )
 

--- a/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/screen/MainScreenViewModel.kt
+++ b/composeApp/src/androidMain/kotlin/com/ddaypunk/aperture/screen/MainScreenViewModel.kt
@@ -46,12 +46,16 @@ class MainScreenViewModel(
 
     private fun List<SelectAllAwardNominees>.toListOfSeasonEntryStates(): List<SeasonEntryState> {
         return this
-            .groupBy { it.awardYear } // map of year: Long to awardNominees: List<SelectAllAwardNominees>
+            .groupBy { it.awardYear }
             .mapNotNull { year ->
                 mapSeasonEntryState(year)
             }
     }
 
+    /**
+     * Create the state for each awards season
+     * @return [SeasonEntryState]
+     */
     private fun mapSeasonEntryState(year: Map.Entry<Long, List<SelectAllAwardNominees>>) =
         SeasonEntryState(
             title = year.key.toString(),
@@ -61,13 +65,22 @@ class MainScreenViewModel(
                 }
         )
 
-    private fun mapExpandableCardState(category: Map.Entry<String, List<SelectAllAwardNominees>>) =
-        ExpandableCardState(
+    /**
+     * Create the state for each expandable card using DB data models
+     * @return [ExpandableCardState] with nominees sorted by winner at top, then by title
+     */
+    private fun mapExpandableCardState(category: Map.Entry<String, List<SelectAllAwardNominees>>): ExpandableCardState {
+        val sorted = category.value.sortedWith(
+            compareBy({ !it.won }, { it.name })
+        )
+
+        return ExpandableCardState(
             title = category.key,
-            nomineeStates = category.value.map { nominee ->
+            nomineeStates = sorted.map { nominee ->
                 mapCheckableRowState(nominee)
             }
         )
+    }
 
     private fun mapCheckableRowState(nominee: SelectAllAwardNominees) =
         CheckableRowState(
@@ -80,10 +93,7 @@ class MainScreenViewModel(
                     isChecked = !nominee.watched
                 )
             },
-            // TODO: make call to KTOR for poster image
-            // TODO: in future, check if in persistence, otherwise make call and store
-            //  image = ,
-            endIcon = getWinnerIcon(nominee.won)
+            isWinner = nominee.won
         )
 
     private fun getWinnerIcon(isWinner: Boolean): Int? {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ androidx-core-ktx = "1.12.0"
 androidx-espresso-core = "3.5.1"
 androidx-material = "1.11.0"
 androidx-test-junit = "1.1.5"
+coil = "2.6.0"
 compose = "1.5.4"
 compose-nav = "2.7.6"
 compose-viewmodel = "2.6.1"
@@ -34,6 +35,7 @@ androidx-constraintlayout = { group = "androidx.constraintlayout", name = "const
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "compose-nav"}
 androidx-lifecycle-compose-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "compose-viewmodel" }
+coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 sqldelight-runtime = { group = "app.cash.sqldelight", name = "runtime", version.ref = "sqldelight" }
 sqldelight-driver-android = { group = "app.cash.sqldelight", name = "android-driver", version.ref = "sqldelight" }
 sqldelight-driver-native = { group = "app.cash.sqldelight", name = "native-driver", version.ref = "sqldelight" }
+sqldelight-coroutines = { group = "app.cash.sqldelight", name = "coroutines-extensions", version.ref = "sqldelight" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -35,6 +35,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(libs.sqldelight.runtime)
+            implementation(libs.sqldelight.coroutines)
             api(libs.koin.core)
             api(libs.koin.test)
             implementation("co.touchlab:stately-common:2.0.5")

--- a/shared/src/commonMain/kotlin/ApertureDatabaseRepository.kt
+++ b/shared/src/commonMain/kotlin/ApertureDatabaseRepository.kt
@@ -1,4 +1,8 @@
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
 import com.ddaypunk.aperture.db.ApertureDatabase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -12,6 +16,9 @@ class ApertureDatabaseRepository : KoinComponent {
     private val awards = database.awardNomineeQueries
 
     fun getAllAwardNominees() = awards.selectAllAwardNominees().executeAsList()
+    fun getAllAwardNomineesFlow() =
+        awards.selectAllAwardNominees().asFlow().mapToList(Dispatchers.IO)
+
     fun updateNomineeWatched(id: Long, isWatched: Boolean) {
         nominees.updateNomineeWatched(id = id, watched = isWatched)
     }

--- a/shared/src/commonMain/sqldelight/com/ddaypunk/aperture/db/Award.sq
+++ b/shared/src/commonMain/sqldelight/com/ddaypunk/aperture/db/Award.sq
@@ -4,5 +4,8 @@ CREATE TABLE award (
   yearId INTEGER REFERENCES year(id)
 );
 
--- 1 - Best Picture - 2024
-INSERT INTO award (categoryId, yearId) VALUES (1, 1);
+INSERT INTO award (categoryId, yearId)
+VALUES
+    (1, 1), -- 1 - Best Motion Picture of the Year - 2024
+    (2, 1), -- 2 - Best Adapted Screenplay - 2024
+    (3, 1); -- 3 - Best Animated Feature Film - 2024

--- a/shared/src/commonMain/sqldelight/com/ddaypunk/aperture/db/AwardNominee.sq
+++ b/shared/src/commonMain/sqldelight/com/ddaypunk/aperture/db/AwardNominee.sq
@@ -8,16 +8,29 @@ CREATE TABLE awardNominee (
     PRIMARY KEY (awardId, nomineeId)
 );
 
-INSERT INTO awardNominee (awardId, nomineeId) VALUES (1, 1);
-INSERT INTO awardNominee (awardId, nomineeId) VALUES (1, 2);
-INSERT INTO awardNominee (awardId, nomineeId) VALUES (1, 3);
-INSERT INTO awardNominee (awardId, nomineeId) VALUES (1, 4);
-INSERT INTO awardNominee (awardId, nomineeId) VALUES (1, 5);
-INSERT INTO awardNominee (awardId, nomineeId) VALUES (1, 6);
-INSERT INTO awardNominee (awardId, nomineeId) VALUES (1, 7);
-INSERT INTO awardNominee (awardId, nomineeId) VALUES (1, 8);
-INSERT INTO awardNominee (awardId, nomineeId) VALUES (1, 9);
-INSERT INTO awardNominee (awardId, nomineeId) VALUES (1, 10);
+INSERT INTO awardNominee (awardId, nomineeId, won)
+VALUES
+    (1, 1, 0),
+    (1, 2, 0),
+    (1, 3, 0),
+    (1, 4, 0),
+    (1, 5, 0),
+    (1, 6, 1),
+    (1, 7, 0),
+    (1, 8, 0),
+    (1, 9, 0),
+    (1, 10, 0),
+    (2,1, 1),
+    (2,3, 0),
+    (2,6, 0),
+    (2,8, 0),
+    (2,10, 0);
+
+-- INSERT INTO awardNominee (awardId, nomineeId) VALUES (2, 11);
+-- INSERT INTO awardNominee (awardId, nomineeId) VALUES (2, 12);
+-- INSERT INTO awardNominee (awardId, nomineeId) VALUES (2, 13);
+-- INSERT INTO awardNominee (awardId, nomineeId) VALUES (2, 14);
+-- INSERT INTO awardNominee (awardId, nomineeId) VALUES (2, 15);
 
 selectAllAwardNominees:
 SELECT category.name AS categoryName, year.year AS awardYear, nominee.id, nominee.name, nominee.type, nominee.secondaryInfo, nominee.watched, won, notes

--- a/shared/src/commonMain/sqldelight/com/ddaypunk/aperture/db/Category.sq
+++ b/shared/src/commonMain/sqldelight/com/ddaypunk/aperture/db/Category.sq
@@ -3,4 +3,8 @@ CREATE TABLE category (
   name TEXT UNIQUE NOT NULL
 );
 
-INSERT INTO category (name) VALUES ("Best Motion Picture of the Year");
+INSERT INTO category (name)
+VALUES
+    ("Best Motion Picture of the Year"), -- 1
+    ("Best Adapted Screenplay"), -- 2
+    ("Best Animated Feature Film"); -- 3

--- a/shared/src/commonMain/sqldelight/com/ddaypunk/aperture/db/Nominee.sq
+++ b/shared/src/commonMain/sqldelight/com/ddaypunk/aperture/db/Nominee.sq
@@ -5,19 +5,27 @@ CREATE TABLE nominee (
   name TEXT NOT NULL,
   type TEXT,
   watched INTEGER AS Boolean DEFAULT 0 NOT NULL, -- we want this to show for multiple categories if needed
-  secondaryInfo TEXT NOT NULL
+  secondaryInfo TEXT NOT NULL,
+  imdbID TEXT NOT NULL
 );
 
-INSERT INTO nominee (name, type, secondaryInfo) VALUES ("American Fiction", "FILM","Ben LeClair,Nikos Karamigios,Cord Jefferson,Jermaine Johnson"); -- 1
-INSERT INTO nominee (name, type, secondaryInfo) VALUES ("Anatomy of a Fall", "FILM", "Marie-Ange Luciani,David Thion"); -- 2
-INSERT INTO nominee (name, type, secondaryInfo) VALUES ("Barbie", "FILM", "David Heyman,Margot Robbie,Tom Ackerley,Robbie Brenner"); -- 3
-INSERT INTO nominee (name, type, secondaryInfo) VALUES ("Killers of the Flower Moon", "FILM", "Dan Friedkin,Bradley Thomas,Martin Scorsese,Daniel Lupi"); -- 4
-INSERT INTO nominee (name, type, secondaryInfo) VALUES ("Maestro", "FILM", "Bradley Cooper,Steven Spielberg,Fred Berner,Amy Durning,Kristie Macosko Krieger"); -- 5
-INSERT INTO nominee (name, type, secondaryInfo) VALUES ("Oppenheimer", "FILM", "Emma Thomas,Charles Roven,Christopher Nolan"); -- 6
-INSERT INTO nominee (name, type, secondaryInfo) VALUES ("Past Lives", "FILM", "David Hinojosa,Christine Vachon,Pamela Koffler"); -- 7
-INSERT INTO nominee (name, type, secondaryInfo) VALUES ("Poor Things", "FILM", "Ed Guine,Andrew Lowe,Yorgos Lanthimos,Emma Stone"); -- 8
-INSERT INTO nominee (name, type, secondaryInfo) VALUES ("The Holdovers", "FILM", "Mark Johnson"); -- 9
-INSERT INTO nominee (name, type, secondaryInfo) VALUES ("The Zone of Interest", "FILM", "James Wilson"); -- 10
+INSERT INTO nominee (name, type, secondaryInfo, imdbID)
+VALUES
+    ("American Fiction", "FILM","Ben LeClair,Nikos Karamigios,Cord Jefferson,Jermaine Johnson", "tt17009710"), -- 1
+    ("Anatomy of a Fall", "FILM", "Marie-Ange Luciani,David Thion", "tt17009710"), -- 2
+    ("Barbie", "FILM", "David Heyman,Margot Robbie,Tom Ackerley,Robbie Brenner", "tt1517268"), -- 3
+    ("Killers of the Flower Moon", "FILM", "Dan Friedkin,Bradley Thomas,Martin Scorsese,Daniel Lupi", "tt5537002"), -- 4
+    ("Maestro", "FILM", "Bradley Cooper,Steven Spielberg,Fred Berner,Amy Durning,Kristie Macosko Krieger", "tt5535276"), -- 5
+    ("Oppenheimer", "FILM", "Emma Thomas,Charles Roven,Christopher Nolan", "tt15398776"), -- 6
+    ("Past Lives", "FILM", "David Hinojosa,Christine Vachon,Pamela Koffler", "tt13238346"), -- 7
+    ("Poor Things", "FILM", "Ed Guine,Andrew Lowe,Yorgos Lanthimos,Emma Stone", "tt14230458"), -- 8
+    ("The Holdovers", "FILM", "Mark Johnson", "tt14849194"), -- 9
+    ("The Zone of Interest", "FILM", "James Wilson", "tt7160372"); -- 10
+--     ("The Boy and the Heron", "FILM", "Hayao Miyazaki, Soma Santoki, Masaki Suda, Kô Shibasaki, Aimyon"),
+--     ("Elemental", "FILM", "Peter Sohn, Leah Lewis, Mamoudou Athie, Ronnie Del Carmen, Shila Ommi"),
+--     ("Nimona", "FILM", "Nick Bruno, Troy Quane, Chloë Grace Moretz, Riz Ahmed, Eugene Lee Yang, Frances Conroy"),
+--     ("Robot Dreams", "FILM", "Pablo Berger, Ivan Labanda, Albert Trifol Segarra, Rafa Calvo, José García Tos"),
+--     ("Spider-Man: Across the Spider-Verse", "FILM", "Joaquim Dos Santos, Kemp Powers, Justin K. Thompson, Shameik Moore, Hailee Steinfeld, Brian Tyree Henry, Luna Lauren Velez"),
 
 updateNomineeWatched:
 UPDATE nominee

--- a/shared/src/iosMain/kotlin/Platform.ios.kt
+++ b/shared/src/iosMain/kotlin/Platform.ios.kt
@@ -1,7 +1,8 @@
 import platform.UIKit.UIDevice
 
 class IOSPlatform : Platform {
-    override val name: String = UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
+    override val name: String =
+        UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
 }
 
 actual fun getPlatform(): Platform = IOSPlatform()

--- a/shared/src/iosMain/kotlin/com.ddaypunk.aperture.di/DatabaseDriverModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com.ddaypunk.aperture.di/DatabaseDriverModule.ios.kt
@@ -1,11 +1,8 @@
 package com.ddaypunk.aperture.di
 
-import ApertureDatabaseRepository
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.native.NativeSqliteDriver
 import com.ddaypunk.aperture.db.ApertureDatabase
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 import org.koin.dsl.module
 
 actual val databaseDriverModule = module {


### PR DESCRIPTION
## Summary
I wanted to update the styling to more closely match the iOS flavor. It keeps it simple for now.

It also adds a bit more data to the db, which allowed two different categories that share similar nominees. As expected, given how the schema is setup and the query to check a nominee as watched, other instances of the same nominee will also update to be checked. I was hoping this happened as it makes it easier on the user to see what they have actually watched!

@gionoa I am planning on expanding the first card in the list by default, once I move the click logic into the viewmodel which will be a part of making the view model platform agnostic.

It looks like some image loading stuff with **Coil** snuck in here which I was experimenting with on the branch and forgot. It will be what Android uses to load the remote images at some point.

![image](https://github.com/ddaypunk/aperture/assets/2991755/90b07b1a-7f33-4a6a-b5ac-ff5e3990d1c7)


## Testing
- App loads on both platforms
- iOS loads data as expected
- Android loads data as expected
    - two expandable cards displayed each with expected data
    - checking an item appearing in both cards checks it in both cards
    - styling looks better